### PR TITLE
Upgrade the hubot slack module to the latest version:

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "hubot-rules": "^0.1.1",
     "hubot-scripts": "^2.16.2",
     "hubot-shipit": "^0.2.0",
-    "hubot-slack": "^3.4.2",
+    "hubot-slack": "^4.0.2",
     "hubot-standup-alarm": "0.0.7",
     "moment": "^2.13.0",
     "xml2js": "^0.4.16",


### PR DESCRIPTION
Updated the hubot-slack module to the latest version. This will hopefully avoid
the problem with hubot disconnecting from slack.

Related to the following problems:
- https://github.com/github/hubot/issues/1013#issuecomment-131013071
- https://github.com/slackhq/hubot-slack/issues/282
