### PR TITLE
Ensure release sub-command can handle libraries:

### DIFF
--- a/scripts/digimap-ci.coffee
+++ b/scripts/digimap-ci.coffee
@@ -134,30 +134,22 @@ deployToBeta = (res, userInfo, days, endMessage) ->
 getParams = (args, res, allowLibraries, callback) ->
   params = args.split(' ')
 
-  app = null
-  groupId = null
-  for element in apps.frontend.apps
-    if element == params[0]
-      app = element
-      groupId = apps.frontend.groupId
-      location = apps.frontend.location
+  app = apps.frontend.apps.find (e) -> e == params[0]
+  groupId = apps.frontend.groupId
+  location = apps.frontend.location
 
-  if app == null
-    for element in apps.services.apps
-      if element == params[0]
-        app = element
-        groupId = apps.services.groupId
-        location = apps.services.location
+  if not app?
+    app = apps.services.apps.find (e) -> e == params[0]
+    groupId = apps.services.groupId
+    location = apps.services.location
 
   # Check also libraries if alowed by the caller
-  if allowLibraries && app == null
-    for element in libraries.apps
-      if element == params[0]
-        app = element
-        groupId = libraries.groupId
-        location = libraries.location
+  if allowLibraries and not app?
+    app = libraries.apps.find (e) -> e == params[0]
+    groupId = libraries.groupId
+    location = libraries.location
 
-  if app == null
+  if not app?
     if allowLibraries
       msg = 'Error: The app or library requested doesn\'t match any known'
     else

--- a/scripts/digimap-ci.coffee
+++ b/scripts/digimap-ci.coffee
@@ -350,7 +350,7 @@ getValidUser = (res) ->
     res.reply "Error: User @#{user} is not permitted to release apps"
     return null
   else
-  return { user: user, token: token.token }
+    return { user: user, token: token.token }
 
 
 module.exports = (robot) ->

--- a/scripts/digimap-ci.coffee
+++ b/scripts/digimap-ci.coffee
@@ -35,7 +35,7 @@ apps =
 libraries =
   location: 'edina/digimap/'
   groupId: 'edina.digimap'
-  apps: ['mapper-framework', 'user-persistence', 'authorisation', 'digimap-logging']
+  apps: ['mapper-framework', 'user-persistence', 'authorisation', 'digimap-logging', 'coordomatic']
 
 # Small helper function to get group ID for an app.
 getGroupId = (app) ->


### PR DESCRIPTION
Added a list of digimap libraries which the get parameters function
can optionally search (i.e. if a release if being executed). In the
case of deploys the library list will not be checked.

Associated issue: https://github.com/edina/edina-hubot/issues/12